### PR TITLE
Add prefix to accessory name

### DIFF
--- a/lang/en.yaml
+++ b/lang/en.yaml
@@ -1,1 +1,1 @@
-temperature.current.name: Outdoor temperature
+temperature.current.name: Nibe outdoor temperature

--- a/lang/pl.yaml
+++ b/lang/pl.yaml
@@ -1,1 +1,1 @@
-temperature.current.name: Temperatura zewnętrzna
+temperature.current.name: Nibe temperatura zewnętrzna


### PR DESCRIPTION
Homekit will remove start of accessory name if something else with this name exists.